### PR TITLE
Try decoding cursor value as datetime only if not numeric

### DIFF
--- a/admin_cursor_paginator/cursor.py
+++ b/admin_cursor_paginator/cursor.py
@@ -40,7 +40,7 @@ def decode_value(val):
     if not val:
         raise ValueError
     try:
-        return _decode_datetime(val)
+        return val if val.isnumeric() else _decode_datetime(val)
     except ValueError:
         return val
 


### PR DESCRIPTION
The problem is that since Python 3.11, `datetime.fromisoformat` can decode values like `"34341005"` to a datetime - it is an ID actually, not a datetime. In Python 3.10 and bellow, this would raise a ValueError.

So to make it consistent with how it behaved before Python 3.11, I'm suggesting checking for `not val.isnumeric()` before passing to `_decode_datetime`.

The problem it causes is that encoded ID value is treated as a datetime in random cases (when the ID is valid for `datetime.fromisoformat`).

Does it make sense @a1tus ? I'm not sure this is the proper fix but I hope the issue is clear.
